### PR TITLE
Eddystone beacons wrongly identified as iBeacons

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -70,10 +70,6 @@ BeaconParser.prototype.parse = function(peripheral) {
 BeaconParser.prototype._detectBeaconType = function(peripheral) {
 	let ad = peripheral.advertisement;
 	let manu = ad.manufacturerData;
-	// iBeacon
-	if(manu && manu.length >= 4 && manu.readUInt32BE(0) === 0x4c000215) {
-		return 'iBeacon';
-	}
 	// Eddiystone
 	let eddystone_service = ad.serviceData.find((el) => {
 		return el.uuid === this._EDDYSTONE_SERVICE_UUID;
@@ -90,6 +86,10 @@ BeaconParser.prototype._detectBeaconType = function(peripheral) {
 		} else if(frame_type === 0b0011) {
 			return 'eddystoneEid';
 		}
+	}
+	// iBeacon
+	if(manu && manu.length >= 4 && manu.readUInt32BE(0) === 0x4c000215) {
+		return 'iBeacon';
 	}
 	// Estimote Telemetry
 	let telemetry_service = ad.serviceData.find((el) => {


### PR DESCRIPTION
Hello,

while using this library on a raspberry pi with 2 sample beacons, I encountered a problem, where after a short while only iBeacons got detected although eddystone beacons were present.

After a short inspection of the code i noticed that in the parser.js the check for iBeacons comes before the check for eddystone beacons. I also noticed that the check for those two kinds of beacons is different. While an eddystone beacon is detected by a unique ServiceUUID, the detection of iBeacons relies on manufacturer data.

After some checks, I realised, that some of the beacons matching the criteria for eddystone (ServiceUUID == "feaa") were classified as iBeacons, because those criteria was also matched.

By rearranging the order of matching (first eddystone then iBeacon), I think I solved the problem. Because my raspberry pi now detects iBeacons and eddystone beacons in roughly the same proprtion.