### PR TITLE
Make txPower from UInt8 to Int8

### DIFF
--- a/lib/parser-ibeacon.js
+++ b/lib/parser-ibeacon.js
@@ -37,7 +37,7 @@ BeaconParserIbeacon.prototype.parse = function(peripheral) {
 		uuid : uuid,
 		major: manu.slice(20, 22).readUInt16BE(0),
 		minor: manu.slice(22, 24).readUInt16BE(0),
-		txPower: manu.slice(24, 25).readUInt8(0)
+		txPower: manu.slice(24, 25).readInt8(0)
 	};
 };
 


### PR DESCRIPTION
iBeacon parser returned txPower as 191 instead of -65. Changed from UInt8 to Int8. Now it matches Eddystone.